### PR TITLE
Fix stage.yaml stat task: drop get_md5 (removed in ansible-core 2.16)

### DIFF
--- a/provision/stage.yaml
+++ b/provision/stage.yaml
@@ -14,7 +14,6 @@
     stat:
       path: '{{ stage_dir }}/blazegraph.jnl'
       get_checksum: False
-      get_md5: False
     register: journal_result
 
   - name: Get remote blazegraph journal


### PR DESCRIPTION
## Problem

Deploying the stack with the current `geneontology/go-devops-base` devops container (ships **ansible-core 2.16.3**) fails at the very first journal-staging step:

```
TASK [Check if journal exists] ...
fatal: FAILED! => {"msg": "Unsupported parameters for (stat) module: get_md5. ..."}
```

The `stat` module's `get_md5` parameter was deprecated in ansible 2.0 and **removed in ansible-core 2.16**, so the playbook aborts before the Blazegraph journal is downloaded/unpacked.

## Fix

Remove the single `get_md5: False` line from the "Check if journal exists" task. `get_checksum: False` directly above it already disables checksum computation, so this is **behavior-preserving** — the task simply stops passing a parameter the module no longer accepts.

## Testing

Verified end-to-end during a live `production-2026-05-29` deploy: with this change the `stat` task passes and the stack deployment proceeds to stage the journal and start services.

---

_Note: this PR fixes the `get_md5` incompatibility only. A separate, unaddressed fragility was observed in the same playbook: for a multi-GB journal, `get_url`'s post-download checksum pass can exceed the `async_status` poll window (45 × 20s = 15 min) and fail the play even though the download itself succeeds. Worth a follow-up (e.g. widen the poll window or skip the redundant checksum), but out of scope here._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_— Posted by Claude Code agent on behalf of @kltm._